### PR TITLE
More route slide fixes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        <link
+          href="https://api.mapbox.com/mapbox-gl-js/v3.1.2/mapbox-gl.css"
+          rel="stylesheet"
+        />
         <style>{`
 html {
   font-family: ${GeistSans.style.fontFamily};

--- a/app/pages/published-page.tsx
+++ b/app/pages/published-page.tsx
@@ -119,7 +119,7 @@ export default function PublishedPage({ shortcode }: { shortcode: string }) {
           destination: item.destination,
           route: item.details.id,
           routeColor: item.details.color,
-          tableTextColor: item.details.textColor,
+          routeTextColor: item.details.textColor,
           time: item.arrivalTime,
           duration: item.arrival,
           status: item.status,

--- a/app/pages/published-page.tsx
+++ b/app/pages/published-page.tsx
@@ -150,8 +150,8 @@ export default function PublishedPage({ shortcode }: { shortcode: string }) {
 
       const route = slideData.selectedRoute;
       const service = route.services[0];
-      const organizationId = service.organization_guid || service.organization_id;
-      const serviceId = service.service_guid || service.service_id;
+      const organizationId = service.organization_guid;
+      const serviceId = service.service_guid;
 
       try {
         setRouteTimesIsLoading(slide.id, true);

--- a/components/slide-previews/route-times-preview.tsx
+++ b/components/slide-previews/route-times-preview.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState, useRef } from 'react';
 import { formatDepartureTime } from '@/services/data-gathering/fetchRouteData';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
+import { renderRouteOnMap, calculateStopBounds, calculateZoomFromBounds } from '@/services/map/renderRouteOnMap';
+import type { RouteDataItem, TripData, StopInfo, Departure, StopWithDepartures, PatternStop } from '@/types/route-times';
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_KEY;
 
@@ -23,9 +25,11 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
   const isLoading = slideData?.isLoading || false;
 
   const [currentTime, setCurrentTime] = useState(Date.now());
-  const mapContainerRef = useRef<HTMLDivElement | null>(null);
+  const [mapLoaded, setMapLoaded] = useState(false);
+  const [mapContainer, setMapContainer] = useState<HTMLDivElement | null>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const markersRef = useRef<mapboxgl.Marker[]>([]);
+  const mapIdRef = useRef<string>(`map-${Math.random().toString(36).substr(2, 9)}`);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -37,174 +41,147 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
 
   // Initialize map when in map view
   useEffect(() => {
-    if (viewMode !== 'map' || !mapContainerRef.current || mapRef.current) {return;}
+    setMapLoaded(false);
+
+    if (viewMode !== 'map') {
+      // Clean up map when switching away from map view
+      if (mapRef.current) {
+        try {
+          markersRef.current.forEach(marker => marker.remove());
+          markersRef.current = [];
+          mapRef.current.remove();
+          mapRef.current = null;
+        } catch (e) {
+          console.error('Error cleaning up map:', e);
+          mapRef.current = null;
+        }
+      }
+      return;
+    }
+
+    // Wait for container to be available
+    if (!mapContainer) {
+      return;
+    }
+
+    // Clean up any existing map
+    if (mapRef.current) {
+      try {
+        markersRef.current.forEach(marker => marker.remove());
+        markersRef.current = [];
+        mapRef.current.remove();
+      } catch (e) {
+        console.error('Error removing existing map:', e);
+      }
+      mapRef.current = null;
+    }
 
     // Calculate initial center from pattern data if available
     let initialCenter: [number, number] = [-73.7562, 42.6526]; // Default to Albany
     let initialZoom = 12;
 
     if (patternData?.stops && patternData.stops.length > 0) {
-      const bounds = new mapboxgl.LngLatBounds();
-
-      patternData.stops.forEach((stop: any) => {
-        let lon, lat;
-        if (stop.coordinates && stop.coordinates.length === 2) {
-          [lon, lat] = stop.coordinates;
-        } else if (stop.lon !== undefined && stop.lat !== undefined) {
-          lon = stop.lon;
-          lat = stop.lat;
-        }
-
-        if (lon !== undefined && lat !== undefined) {
-          bounds.extend([lon, lat]);
-        }
-      });
-
-      if (!bounds.isEmpty()) {
+      const bounds = calculateStopBounds(patternData.stops);
+      if (bounds) {
         const center = bounds.getCenter();
         initialCenter = [center.lng, center.lat];
-
-        // Calculate appropriate zoom level based on bounds
-        const ne = bounds.getNorthEast();
-        const sw = bounds.getSouthWest();
-        const latDiff = Math.abs(ne.lat - sw.lat);
-        const lngDiff = Math.abs(ne.lng - sw.lng);
-        const maxDiff = Math.max(latDiff, lngDiff);
-
-        if (maxDiff < 0.01) {initialZoom = 15;}
-        else if (maxDiff < 0.05) {initialZoom = 13;}
-        else if (maxDiff < 0.1) {initialZoom = 12;}
-        else if (maxDiff < 0.5) {initialZoom = 10;}
-        else {initialZoom = 9;}
+        initialZoom = calculateZoomFromBounds(bounds);
       }
     }
 
-    mapRef.current = new mapboxgl.Map({
-      container: mapContainerRef.current,
-      style: 'mapbox://styles/mapbox/light-v11',
-      center: initialCenter,
-      zoom: initialZoom,
-      attributionControl: false,
-    });
+    try {
+      // Create new map
+      const map = new mapboxgl.Map({
+        container: mapContainer,
+        style: 'mapbox://styles/mapbox/light-v11',
+        center: initialCenter,
+        zoom: initialZoom,
+        attributionControl: false,
+      });
 
-    // Disable interactions for preview
-    mapRef.current.dragPan.disable();
-    mapRef.current.scrollZoom.disable();
-    mapRef.current.boxZoom.disable();
-    mapRef.current.dragRotate.disable();
-    mapRef.current.keyboard.disable();
-    mapRef.current.doubleClickZoom.disable();
-    mapRef.current.touchZoomRotate.disable();
+      // Store reference
+      mapRef.current = map;
+
+      // Disable interactions for preview
+      map.dragPan.disable();
+      map.scrollZoom.disable();
+      map.boxZoom.disable();
+      map.dragRotate.disable();
+      map.keyboard.disable();
+      map.doubleClickZoom.disable();
+      map.touchZoomRotate.disable();
+
+      // Force a resize and mark as loaded after map loads
+      map.once('load', () => {
+        map.resize();
+        setMapLoaded(true);
+
+        // Add route and stops data if available
+        if (patternData) {
+          const newMarkers = renderRouteOnMap({
+            map,
+            patternData,
+            selectedRoute,
+            markers: markersRef.current,
+          });
+          markersRef.current = newMarkers;
+        }
+      });
+    } catch (e) {
+      console.error('Error creating map:', e);
+    }
 
     return () => {
-      markersRef.current.forEach(marker => marker.remove());
-      markersRef.current = [];
-      mapRef.current?.remove();
-      mapRef.current = null;
+      setMapLoaded(false);
+      if (mapRef.current) {
+        try {
+          markersRef.current.forEach(marker => marker.remove());
+          markersRef.current = [];
+          mapRef.current.remove();
+          mapRef.current = null;
+        } catch (e) {
+          console.error('Error in cleanup:', e);
+          mapRef.current = null;
+        }
+      }
     };
-  }, [viewMode, patternData]);
+  }, [viewMode, slideId, mapContainer, patternData, selectedRoute]);
 
-  // Update map with route data
+  // Update map with pattern data changes
   useEffect(() => {
     if (!mapRef.current || viewMode !== 'map' || !patternData) {return;}
 
-    const updateMap = () => {
+    const updateMapData = () => {
       if (!mapRef.current) {return;}
 
-      // Clear existing markers and layers
-      markersRef.current.forEach(marker => marker.remove());
-      markersRef.current = [];
-
-      // Remove existing route layer if it exists
-      if (mapRef.current.getLayer('route-line')) {
-        mapRef.current.removeLayer('route-line');
-      }
-      if (mapRef.current.getSource('route')) {
-        mapRef.current.removeSource('route');
-      }
-
-      // Add route line if we have coordinates
-      if (patternData.coordinates && patternData.coordinates.length > 0) {
-        mapRef.current.addSource('route', {
-        type: 'geojson',
-        data: {
-          type: 'Feature',
-          properties: {},
-          geometry: {
-            type: 'LineString',
-            coordinates: patternData.coordinates,
-          },
-        },
+      // Render route and stops
+      const newMarkers = renderRouteOnMap({
+        map: mapRef.current,
+        patternData,
+        selectedRoute,
+        markers: markersRef.current,
       });
+      markersRef.current = newMarkers;
 
-      mapRef.current.addLayer({
-        id: 'route-line',
-        type: 'line',
-        source: 'route',
-        layout: {
-          'line-join': 'round',
-          'line-cap': 'round',
-        },
-        paint: {
-          'line-color': selectedRoute?.route_color ? `#${selectedRoute.route_color}` : '#0074D9',
-          'line-width': 4,
-          'line-opacity': 0.8,
-        },
-      });
-    }
-
-    // Add stop markers
-    if (patternData.stops && patternData.stops.length > 0) {
-      patternData.stops.forEach((stop: any, index: number) => {
-        // Check for coordinates in different formats
-        let lon, lat;
-        if (stop.coordinates && stop.coordinates.length === 2) {
-          [lon, lat] = stop.coordinates;
-        } else if (stop.lon !== undefined && stop.lat !== undefined) {
-          lon = stop.lon;
-          lat = stop.lat;
-        } else {
-          return; // Skip this stop if no valid coordinates
+      // Update bounds if we have stops
+      if (patternData.stops && patternData.stops.length > 0) {
+        const bounds = calculateStopBounds(patternData.stops);
+        if (bounds) {
+          mapRef.current.fitBounds(bounds, {
+            padding: 50,
+            maxZoom: 15,
+          });
         }
-
-        // Create marker element
-        const markerEl = document.createElement('div');
-        markerEl.className = 'route-stop-marker';
-        markerEl.style.cssText = `
-          width: 24px;
-          height: 24px;
-          background: ${selectedRoute?.route_color ? `#${selectedRoute.route_color}` : '#0074D9'};
-          color: ${selectedRoute?.route_text_color ? `#${selectedRoute.route_text_color}` : '#FFFFFF'};
-          border: 2px solid white;
-          border-radius: 50%;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          font-weight: bold;
-          font-size: 12px;
-          box-shadow: 0 2px 6px rgba(0,0,0,0.3);
-        `;
-        markerEl.textContent = (index + 1).toString();
-
-        const marker = new mapboxgl.Marker({
-          element: markerEl,
-          anchor: 'center',
-        })
-          .setLngLat([lon, lat])
-          .addTo(mapRef.current);
-
-        markersRef.current.push(marker);
-      });
-    }
+      }
     };
 
-    // Check if map is loaded, if not wait for it
-    if (mapRef.current.isStyleLoaded()) {
-      updateMap();
+    // Wait for map to be loaded before updating
+    if (mapRef.current.loaded()) {
+      updateMapData();
     } else {
-      mapRef.current.once('load', updateMap);
+      mapRef.current.once('load', updateMapData);
     }
-  }, [viewMode, patternData, selectedRoute]);
+  }, [patternData, selectedRoute, viewMode]);
 
   // Helper function to format time for timetable view
   const formatTimetableTime = (timestamp: number) => {
@@ -218,19 +195,19 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
   };
 
   // Get unique trips for timetable view
-  const getUniqueTrips = () => {
+  const getUniqueTrips = (): TripData[] => {
     if (!routeData || routeData.length === 0) {return [];}
 
-    const tripsMap = new Map();
+    const tripsMap = new Map<string, TripData>();
 
     // Process timetable data format (from fetchRouteTimetable)
-    routeData.forEach(item => {
+    (routeData as RouteDataItem[]).forEach(item => {
       // Check if this is timetable format with stops array containing departures
-      if (item.stops && item.stops[0]?.departures) {
-        const stop = item.stops[0];
+      if (item.stops && item.stops[0] && 'departures' in item.stops[0]) {
+        const stop = item.stops[0] as StopWithDepartures;
         const stopId = stop.stopId || stop.stop_id;
 
-        stop.departures.forEach((dep: any) => {
+        stop.departures?.forEach((dep: Departure) => {
           if (!tripsMap.has(dep.tripId)) {
             tripsMap.set(dep.tripId, {
               tripId: dep.tripId,
@@ -238,7 +215,10 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
               stops: new Map(),
             });
           }
-          tripsMap.get(dep.tripId).stops.set(stopId, dep);
+          const tripData = tripsMap.get(dep.tripId);
+          if (tripData) {
+            tripData.stops.set(stopId, dep);
+          }
         });
       }
     });
@@ -246,8 +226,8 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
     // Sort trips by first departure time
     const trips = Array.from(tripsMap.values());
     trips.sort((a, b) => {
-      const aFirstDep = Array.from(a.stops.values())[0];
-      const bFirstDep = Array.from(b.stops.values())[0];
+      const aFirstDep = Array.from(a.stops.values())[0] as Departure | undefined;
+      const bFirstDep = Array.from(b.stops.values())[0] as Departure | undefined;
       return (aFirstDep?.departTime || 0) - (bFirstDep?.departTime || 0);
     });
 
@@ -255,18 +235,18 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
   };
 
   // Get all stops for timetable columns
-  const getAllStops = () => {
+  const getAllStops = (): StopInfo[] => {
     // First try patternData stops
     if (patternData?.stops && patternData.stops.length > 0) {
-      return patternData.stops.map((stop: any) => ({
-        id: stop.stopId || stop.id,
-        name: stop.name || stop.stopName,
+      return patternData.stops.map((stop: PatternStop) => ({
+        id: stop.stopId || stop.id || '',
+        name: stop.name || stop.stopName || '',
       }));
     }
 
     // Fall back to routeData if available
     if (routeData && routeData.length > 0) {
-      return routeData.map((item: any) => {
+      return (routeData as RouteDataItem[]).map((item) => {
         const stop = item.stops?.[0];
         return {
           id: stop?.stopId || stop?.stop_id || '',
@@ -280,7 +260,6 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
 
   const renderMapView = () => {
     const stops = patternData?.stops || [];
-    const departures = routeData[0]?.stops[0]?.departures || [];
 
     return (
       <div className="flex h-full">
@@ -289,16 +268,24 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
           <div className="p-4">
             <h3 className="font-semibold mb-3" style={{ color: tableTextColor }}>Stop Times</h3>
             <div className="space-y-3">
-              {stops.map((stop: any, index: number) => {
+              {stops.map((stop: PatternStop, index: number) => {
                 // Find departures for this stop - check both stop.id and stop.stopId
                 const stopId = stop.stopId || stop.id;
-                const stopDepartures = routeData.find(rd =>
-                  rd.stops[0]?.stop_id === stopId || rd.stops[0]?.stopId === stopId
-                )?.stops[0]?.departures || [];
+                const stopData = (routeData as RouteDataItem[]).find(rd => {
+                  const firstStop = rd.stops[0];
+                  return firstStop && (
+                    firstStop.stop_id === stopId ||
+                    ('stopId' in firstStop && (firstStop as StopWithDepartures).stopId === stopId)
+                  );
+                });
+
+                const stopDepartures = stopData?.stops[0] && 'departures' in stopData.stops[0]
+                  ? (stopData.stops[0] as StopWithDepartures).departures
+                  : [];
 
                 // Get next 4 upcoming departures
                 const upcomingDepartures = stopDepartures
-                  .filter((dep: any) => dep.departTime >= currentTime)
+                  .filter((dep: Departure) => dep.departTime >= currentTime)
                   .slice(0, 4);
 
                 return (
@@ -319,7 +306,7 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
                         </div>
                         {upcomingDepartures.length > 0 ? (
                           <div className="flex flex-wrap gap-x-2 gap-y-1">
-                            {upcomingDepartures.map((dep: any, depIndex: number) => (
+                            {upcomingDepartures.map((dep: Departure, depIndex: number) => (
                               <div
                                 key={`${dep.tripId}-${depIndex}`}
                                 className="text-xs"
@@ -355,15 +342,25 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
         </div>
 
         {/* Right Panel - Map */}
-        <div className="flex-1 relative">
+        <div className="flex-1 relative" style={{ minHeight: '400px' }}>
           <div
-            ref={mapContainerRef}
+            ref={setMapContainer}
+            id={mapIdRef.current}
             className="absolute inset-0"
             style={{
               width: '100%',
               height: '100%',
+              visibility: mapLoaded ? 'visible' : 'hidden',
             }}
           />
+          {!mapLoaded && (
+            <div className="absolute inset-0 flex items-center justify-center bg-gray-100">
+              <div className="text-center">
+                <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-blue-500 mx-auto mb-2" />
+                <p className="text-gray-500">Loading map...</p>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     );
@@ -394,7 +391,7 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
                     Trip
                   </th>
                 )}
-                {displayStops.map((stop: any) => (
+                {displayStops.map((stop: StopInfo) => (
                   <th
                     key={stop.id}
                     className="text-center p-3 border-b-2 font-semibold"
@@ -406,7 +403,7 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
               </tr>
             </thead>
             <tbody>
-              {trips.slice(0, 10).map((trip: any, tripIndex: number) => (
+              {trips.slice(0, 10).map((trip: TripData, tripIndex: number) => (
                 <tr key={trip.tripId} className={tripIndex % 2 === 0 ? 'bg-gray-50' : ''}>
                   {showTripColumn && (
                     <td
@@ -427,7 +424,7 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
                       </div>
                     </td>
                   )}
-                  {displayStops.map((stop: any) => {
+                  {displayStops.map((stop: StopInfo) => {
                     const departure = trip.stops.get(stop.id);
                     return (
                       <td

--- a/components/slide-previews/route-times-preview.tsx
+++ b/components/slide-previews/route-times-preview.tsx
@@ -487,18 +487,13 @@ export default function RouteTimesPreview({ slideId }: { slideId: string }) {
   return (
     <div
       className="h-full flex flex-col relative"
-      style={{ backgroundColor }}
+      style={{
+        backgroundColor: !bgImage ? backgroundColor : undefined,
+        backgroundImage: bgImage ? `url(${bgImage})` : undefined,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+      }}
     >
-      {bgImage && (
-        <div
-          className="absolute inset-0 opacity-10"
-          style={{
-            backgroundImage: `url(${bgImage})`,
-            backgroundSize: 'cover',
-            backgroundPosition: 'center',
-          }}
-        />
-      )}
 
       {/* Header */}
       <div className="p-4 relative z-10">

--- a/components/slides/route-times.tsx
+++ b/components/slides/route-times.tsx
@@ -351,14 +351,14 @@ export default function RouteTimesSlide({
                   <Button
                     variant={viewMode === 'map' ? 'default' : 'outline'}
                     onClick={() => handleViewModeChange('map')}
-                    className={viewMode === 'map' ? 'bg-[#face00] text-black' : ''}
+                    className={viewMode === 'map' ? 'bg-[#face00] hover:bg-[#face00]/90 text-black' : 'hover:bg-gray-100'}
                   >
                     Map View
                   </Button>
                   <Button
                     variant={viewMode === 'timetable' ? 'default' : 'outline'}
                     onClick={() => handleViewModeChange('timetable')}
-                    className={viewMode === 'timetable' ? 'bg-[#face00] text-black' : ''}
+                    className={viewMode === 'timetable' ? 'bg-[#face00] hover:bg-[#face00]/90 text-black' : 'hover:bg-gray-100'}
                   >
                     Timetable View
                   </Button>

--- a/components/slides/route-times.tsx
+++ b/components/slides/route-times.tsx
@@ -153,14 +153,20 @@ export default function RouteTimesSlide({
       if (specificRoute && specificRoute.patterns && specificRoute.patterns.length > 0) {
         const combinedPatternData = processRoutePatterns(specificRoute.patterns);
         if (combinedPatternData) {
+          const hadPatternDataBefore = !!slideData?.patternData;
+
           setPatternData(slideId, combinedPatternData);
 
-          // Auto-select view mode based on stop count
-          const stopCount = combinedPatternData.stops.length;
-          if (stopCount <= 5) {
-            setViewMode(slideId, 'timetable');
-          } else {
-            setViewMode(slideId, 'map');
+          // Only auto-select view mode if this is truly a new route selection
+          // (no previous pattern data AND no explicit view mode set)
+          if (!hadPatternDataBefore) {
+            // Auto-select view mode based on stop count
+            const stopCount = combinedPatternData.stops.length;
+            if (stopCount <= 5) {
+              setViewMode(slideId, 'timetable');
+            } else {
+              setViewMode(slideId, 'map');
+            }
           }
         }
       }

--- a/components/slides/route-times.tsx
+++ b/components/slides/route-times.tsx
@@ -8,11 +8,7 @@ import { deleteImage } from '@/services/deleteImage';
 import { uploadImage } from '@/services/uploadImage';
 import { useGeneralStore } from '@/stores/general';
 import { fetchRoutes } from '@/services/data-gathering/fetchRoutes';
-import {
-  fetchRouteData,
-  fetchRouteTimetable,
-} from '@/services/data-gathering/fetchRouteData';
-import { processRoutePatterns, formatTimetableData } from '@/services/data-gathering/processRoutePatterns';
+import { fetchCompleteRouteData } from '@/services/route-times/routeDataFetcher';
 
 export default function RouteTimesSlide({
   slideId,
@@ -132,62 +128,25 @@ export default function RouteTimesSlide({
     try {
       setIsLoading(slideId, true);
 
-      const service = route.services[0];
-      const organizationId = service.organization_guid || service.organization_id;
-      const serviceId = service.service_guid || service.service_id;
+      const result = await fetchCompleteRouteData(route);
 
-      // Fetch route patterns and geometry
-      const routeDataArray = await fetchRouteData(
-        organizationId,
-        [serviceId],
-        true,
-        true
-      );
+      if (result.patternData) {
+        const hadPatternDataBefore = !!slideData?.patternData;
+        setPatternData(slideId, result.patternData);
 
-      // Find the specific route from the results
-      const specificRoute = routeDataArray.find(r =>
-        r.id === route.route_id ||
-        r.shortName === route.route_short_name
-      );
-
-      if (specificRoute && specificRoute.patterns && specificRoute.patterns.length > 0) {
-        const combinedPatternData = processRoutePatterns(specificRoute.patterns);
-        if (combinedPatternData) {
-          const hadPatternDataBefore = !!slideData?.patternData;
-
-          setPatternData(slideId, combinedPatternData);
-
-          // Only auto-select view mode if this is truly a new route selection
-          // (no previous pattern data AND no explicit view mode set)
-          if (!hadPatternDataBefore) {
-            // Auto-select view mode based on stop count
-            const stopCount = combinedPatternData.stops.length;
-            if (stopCount <= 5) {
-              setViewMode(slideId, 'timetable');
-            } else {
-              setViewMode(slideId, 'map');
-            }
+        // Only auto-select view mode if this is truly a new route selection
+        if (!hadPatternDataBefore) {
+          // Auto-select view mode based on stop count
+          const stopCount = result.patternData.stops.length;
+          if (stopCount <= 5) {
+            setViewMode(slideId, 'timetable');
+          } else {
+            setViewMode(slideId, 'map');
           }
         }
       }
 
-      // Fetch timetable data
-      const now = Date.now();
-      const endTime = now + (3 * 60 * 60 * 1000); // 3 hours from now
-
-      const timetableData = await fetchRouteTimetable(
-        organizationId,
-        serviceId,
-        route.route_id,
-        now,
-        endTime
-      );
-
-      if (timetableData) {
-        const formattedData = formatTimetableData(timetableData);
-        setRouteData(slideId, formattedData);
-      }
-
+      setRouteData(slideId, result.timetableData, result.isNextDay, result.isLaterToday);
       setIsLoading(slideId, false);
     } catch (error) {
       console.error('Error fetching route data:', error);

--- a/components/slides/stop-arrivals.tsx
+++ b/components/slides/stop-arrivals.tsx
@@ -192,7 +192,7 @@ export default function StopArrivalsSlide({ slideId, handleDelete, handlePreview
           destination: item.destination,
           route: item.details.id,
           routeColor: item.details.color,
-          tableTextColor: item.details.textColor,
+          routeTextColor: item.details.textColor,
           time: item.arrivalTime,
           duration: item.arrival,
           status: item.status,

--- a/services/data-gathering/fetchRouteData.ts
+++ b/services/data-gathering/fetchRouteData.ts
@@ -1,3 +1,5 @@
+import { formatTime12Hour } from '@/utils/timeFormatters';
+
 // Types for route timetable API
 interface RouteTimetableResponse {
   route: {
@@ -363,13 +365,7 @@ export function formatDepartureTime(
     return `${diffMinutes} min`;
   } else {
     // Show actual time for departures more than an hour away
-    const date = new Date(departureTime);
-    const hours = date.getHours();
-    const minutes = date.getMinutes();
-    const ampm = hours >= 12 ? 'PM' : 'AM';
-    const displayHours = hours % 12 || 12;
-    const displayMinutes = minutes.toString().padStart(2, '0');
-    return `${displayHours}:${displayMinutes} ${ampm}`;
+    return formatTime12Hour(departureTime);
   }
 }
 

--- a/services/map/renderRouteOnMap.ts
+++ b/services/map/renderRouteOnMap.ts
@@ -1,0 +1,164 @@
+import mapboxgl from 'mapbox-gl';
+
+export interface RouteMapOptions {
+  map: mapboxgl.Map;
+  patternData: {
+    coordinates?: number[][];
+    stops?: Array<{
+      id?: string;
+      stopId?: string;
+      name?: string;
+      stopName?: string;
+      coordinates?: number[];
+      lon?: number;
+      lat?: number;
+    }>;
+  };
+  selectedRoute?: {
+    route_color?: string;
+    route_text_color?: string;
+  };
+  markers?: mapboxgl.Marker[];
+}
+
+/**
+ * Renders a route line and stop markers on a Mapbox map
+ * Returns an array of markers that were added
+ */
+export function renderRouteOnMap({
+  map,
+  patternData,
+  selectedRoute,
+  markers = [],
+}: RouteMapOptions): mapboxgl.Marker[] {
+  // Clear existing markers
+  markers.forEach(marker => marker.remove());
+  const newMarkers: mapboxgl.Marker[] = [];
+
+  // Remove existing route layer if it exists
+  if (map.getLayer('route-line')) {
+    map.removeLayer('route-line');
+  }
+  if (map.getSource('route')) {
+    map.removeSource('route');
+  }
+
+  // Add route line if we have coordinates
+  if (patternData.coordinates && patternData.coordinates.length > 0) {
+    map.addSource('route', {
+      type: 'geojson',
+      data: {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'LineString',
+          coordinates: patternData.coordinates,
+        },
+      },
+    });
+
+    map.addLayer({
+      id: 'route-line',
+      type: 'line',
+      source: 'route',
+      layout: {
+        'line-join': 'round',
+        'line-cap': 'round',
+      },
+      paint: {
+        'line-color': selectedRoute?.route_color ? `#${selectedRoute.route_color}` : '#0074D9',
+        'line-width': 4,
+        'line-opacity': 0.8,
+      },
+    });
+  }
+
+  // Add stop markers
+  if (patternData.stops && patternData.stops.length > 0) {
+    patternData.stops.forEach((stop: any, index: number) => {
+      // Check for coordinates in different formats
+      let lon, lat;
+      if (stop.coordinates && stop.coordinates.length === 2) {
+        [lon, lat] = stop.coordinates;
+      } else if (stop.lon !== undefined && stop.lat !== undefined) {
+        lon = stop.lon;
+        lat = stop.lat;
+      } else {
+        return; // Skip this stop if no valid coordinates
+      }
+
+      // Create marker element
+      const markerEl = document.createElement('div');
+      markerEl.className = 'route-stop-marker';
+      markerEl.style.cssText = `
+        width: 24px;
+        height: 24px;
+        background: ${selectedRoute?.route_color ? `#${selectedRoute.route_color}` : '#0074D9'};
+        color: ${selectedRoute?.route_text_color ? `#${selectedRoute.route_text_color}` : '#FFFFFF'};
+        border: 2px solid white;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: bold;
+        font-size: 12px;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+        z-index: 10;
+      `;
+      markerEl.textContent = (index + 1).toString();
+
+      const marker = new mapboxgl.Marker({
+        element: markerEl,
+        anchor: 'center',
+      })
+        .setLngLat([lon, lat])
+        .addTo(map);
+
+      newMarkers.push(marker);
+    });
+  }
+
+  return newMarkers;
+}
+
+/**
+ * Calculate bounds for a set of stops
+ */
+export function calculateStopBounds(stops: any[]): mapboxgl.LngLatBounds | null {
+  if (!stops || stops.length === 0) {return null;}
+
+  const bounds = new mapboxgl.LngLatBounds();
+
+  stops.forEach((stop: any) => {
+    let lon, lat;
+    if (stop.coordinates && stop.coordinates.length === 2) {
+      [lon, lat] = stop.coordinates;
+    } else if (stop.lon !== undefined && stop.lat !== undefined) {
+      lon = stop.lon;
+      lat = stop.lat;
+    }
+
+    if (lon !== undefined && lat !== undefined) {
+      bounds.extend([lon, lat]);
+    }
+  });
+
+  return bounds.isEmpty() ? null : bounds;
+}
+
+/**
+ * Calculate appropriate zoom level based on bounds
+ */
+export function calculateZoomFromBounds(bounds: mapboxgl.LngLatBounds): number {
+  const ne = bounds.getNorthEast();
+  const sw = bounds.getSouthWest();
+  const latDiff = Math.abs(ne.lat - sw.lat);
+  const lngDiff = Math.abs(ne.lng - sw.lng);
+  const maxDiff = Math.max(latDiff, lngDiff);
+
+  if (maxDiff < 0.01) {return 15;}
+  else if (maxDiff < 0.05) {return 13;}
+  else if (maxDiff < 0.1) {return 12;}
+  else if (maxDiff < 0.5) {return 10;}
+  else {return 9;}
+}

--- a/services/route-times/routeDataFetcher.ts
+++ b/services/route-times/routeDataFetcher.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared utility for fetching route data consistently across components
+ */
+
+import { fetchRouteData, fetchRouteTimetable } from '../data-gathering/fetchRouteData';
+import { processRoutePatterns, formatTimetableData } from '../data-gathering/processRoutePatterns';
+import { calculateTimeWindow } from './timeWindowCalculator';
+
+export interface RouteInfo {
+  route_id: string;
+  route_short_name?: string;
+  route_long_name?: string;
+  services: Array<{
+    organization_guid?: string;
+    organization_id?: string;
+    service_guid?: string;
+    service_id?: string;
+  }>;
+}
+
+export interface FetchRouteDataResult {
+  patternData?: any;
+  timetableData: any[];
+  isNextDay: boolean;
+  isLaterToday: boolean;
+}
+
+/**
+ * Extract organization and service IDs from a route object
+ */
+export function extractRouteIds(route: RouteInfo) {
+  const service = route.services[0];
+  const organizationId = service.organization_guid || service.organization_id || '';
+  const serviceId = service.service_guid || service.service_id || '';
+  return { organizationId, serviceId };
+}
+
+/**
+ * Find a specific route from an array of route data
+ */
+export function findSpecificRoute(routeDataArray: any[], route: RouteInfo) {
+  return routeDataArray.find(r =>
+    r.id === route.route_id ||
+    r.shortName === route.route_short_name
+  );
+}
+
+/**
+ * Fetch route patterns and geometry data
+ */
+export async function fetchRoutePatterns(
+  route: RouteInfo
+): Promise<any | null> {
+  const { organizationId, serviceId } = extractRouteIds(route);
+
+  const routeDataArray = await fetchRouteData(
+    organizationId,
+    [serviceId],
+    true,
+    true
+  );
+
+  const specificRoute = findSpecificRoute(routeDataArray, route);
+
+  if (specificRoute && specificRoute.patterns && specificRoute.patterns.length > 0) {
+    return processRoutePatterns(specificRoute.patterns);
+  }
+
+  return null;
+}
+
+/**
+ * Fetch route timetable data with automatic next-period fallback
+ */
+export async function fetchRouteTimetableWithFallback(
+  route: RouteInfo,
+  fetchNextPeriod: boolean = false
+): Promise<FetchRouteDataResult> {
+  const { organizationId, serviceId } = extractRouteIds(route);
+  const timeWindow = calculateTimeWindow(fetchNextPeriod);
+
+  let timetableData = await fetchRouteTimetable(
+    organizationId,
+    serviceId,
+    route.route_id,
+    timeWindow.startTime,
+    timeWindow.endTime
+  );
+
+  // If no data and we haven't tried next period yet, try it
+  if (!fetchNextPeriod && (!timetableData || formatTimetableData(timetableData).length === 0)) {
+    // Recursively fetch next period
+    return fetchRouteTimetableWithFallback(route, true);
+  }
+
+  return {
+    patternData: null,
+    timetableData: timetableData ? formatTimetableData(timetableData) : [],
+    isNextDay: timeWindow.isNextDay,
+    isLaterToday: timeWindow.isLaterToday,
+  };
+}
+
+/**
+ * Complete route data fetch including patterns and timetable
+ */
+export async function fetchCompleteRouteData(
+  route: RouteInfo,
+  skipPatterns: boolean = false
+): Promise<FetchRouteDataResult> {
+  let patternData = null;
+
+  if (!skipPatterns) {
+    patternData = await fetchRoutePatterns(route);
+  }
+
+  const timetableResult = await fetchRouteTimetableWithFallback(route, false);
+
+  return {
+    ...timetableResult,
+    patternData,
+  };
+}

--- a/services/route-times/timeWindowCalculator.ts
+++ b/services/route-times/timeWindowCalculator.ts
@@ -1,0 +1,65 @@
+/**
+ * Utility for calculating time windows for route schedule fetching
+ */
+
+export interface TimeWindow {
+  startTime: number;
+  endTime: number;
+  isNextDay: boolean;
+  isLaterToday: boolean;
+}
+
+/**
+ * Calculate the appropriate time window for fetching route schedules
+ * @param fetchNextPeriod - Whether to fetch the next period (tomorrow or later today)
+ * @returns TimeWindow object with start/end times and flags
+ */
+export function calculateTimeWindow(fetchNextPeriod: boolean = false): TimeWindow {
+  const now = Date.now();
+  let startTime = now;
+  let endTime = now + (3 * 60 * 60 * 1000); // 3 hours from now by default
+  let isNextDay = false;
+  let isLaterToday = false;
+
+  if (fetchNextPeriod) {
+    const currentDate = new Date();
+    const currentHour = currentDate.getHours();
+
+    // If it's early morning (before 4 AM), fetch rest of today first
+    if (currentHour < 4) {
+      // Fetch from now until end of service day (4 AM next calendar day)
+      const endOfServiceDay = new Date();
+      endOfServiceDay.setDate(endOfServiceDay.getDate() + 1);
+      endOfServiceDay.setHours(4, 0, 0, 0);
+      startTime = now;
+      endTime = endOfServiceDay.getTime();
+      isNextDay = true;
+      isLaterToday = true;
+    } else {
+      // It's after 4 AM, so fetch tomorrow's data
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(4, 0, 0, 0); // Start at 4 AM tomorrow
+      startTime = tomorrow.getTime();
+      endTime = startTime + (24 * 60 * 60 * 1000); // Full next day
+      isNextDay = true;
+      isLaterToday = false;
+    }
+  }
+
+  return {
+    startTime,
+    endTime,
+    isNextDay,
+    isLaterToday,
+  };
+}
+
+/**
+ * Determine if we're in the early morning hours (late night service period)
+ * @returns true if current time is between midnight and 4 AM
+ */
+export function isEarlyMorningHours(): boolean {
+  const currentHour = new Date().getHours();
+  return currentHour < 4;
+}

--- a/stores/routeTimes.ts
+++ b/stores/routeTimes.ts
@@ -41,6 +41,8 @@ interface RouteTimesSlide {
   routeData: RouteScheduleData[];
   patternData?: any;
   isLoading: boolean;
+  isShowingNextDay?: boolean;
+  isShowingLaterToday?: boolean;
 }
 
 interface RouteTimesStore {
@@ -56,7 +58,7 @@ interface RouteTimesStore {
   setTableColor: (slideId: string, color: string) => void;
   setTableTextColor: (slideId: string, color: string) => void;
   setBgImage: (slideId: string, image: string) => void;
-  setRouteData: (slideId: string, data: RouteScheduleData[]) => void;
+  setRouteData: (slideId: string, data: RouteScheduleData[], isNextDay?: boolean, isLaterToday?: boolean) => void;
   setPatternData: (slideId: string, data: any) => void;
   setIsLoading: (slideId: string, loading: boolean) => void;
   clearSlide: (slideId: string) => void;
@@ -75,6 +77,8 @@ const getDefaultSlide = (): RouteTimesSlide => ({
   routeData: [],
   patternData: undefined,
   isLoading: false,
+  isShowingNextDay: false,
+  isShowingLaterToday: false,
 });
 
 export const useRouteTimesStore = create<RouteTimesStore>()(
@@ -192,7 +196,7 @@ export const useRouteTimesStore = create<RouteTimesStore>()(
           },
         })),
 
-      setRouteData: (slideId, data) =>
+      setRouteData: (slideId, data, isNextDay = false, isLaterToday = false) =>
         set((state) => ({
           slides: {
             ...state.slides,
@@ -200,6 +204,8 @@ export const useRouteTimesStore = create<RouteTimesStore>()(
               ...getDefaultSlide(),
               ...state.slides[slideId],
               routeData: data,
+              isShowingNextDay: isNextDay && !isLaterToday,
+              isShowingLaterToday: isLaterToday,
             },
           },
         })),
@@ -230,7 +236,9 @@ export const useRouteTimesStore = create<RouteTimesStore>()(
 
       clearSlide: (slideId) =>
         set((state) => {
-          const { [slideId]: _, ...remainingSlides } = state.slides;
+          const remainingSlides = Object.fromEntries(
+            Object.entries(state.slides).filter(([key]) => key !== slideId)
+          );
           return { slides: remainingSlides };
         }),
     }),

--- a/types/route-times.ts
+++ b/types/route-times.ts
@@ -1,0 +1,67 @@
+// Types for route times data structures
+
+export interface Departure {
+  tripId: string;
+  headsign: string;
+  departTime: number;
+  realtime?: boolean;
+}
+
+export interface StopWithDepartures {
+  stopId: string;
+  stop_id: string;
+  stopName: string;
+  stop_name: string;
+  stop_lat: number;
+  stop_lon: number;
+  arrival_time: string | null;
+  departure_time: string | null;
+  stop_sequence: number;
+  departures: Departure[];
+}
+
+export interface RouteDataItem {
+  trip_id: string;
+  stops: StopWithDepartures[];
+}
+
+export interface TripData {
+  tripId: string;
+  headsign: string;
+  stops: Map<string, Departure>;
+}
+
+export interface StopInfo {
+  id: string;
+  name: string;
+}
+
+export interface PatternStop {
+  id?: string;
+  stopId?: string;
+  name?: string;
+  stopName?: string;
+  coordinates?: number[];
+  lon?: number;
+  lat?: number;
+}
+
+export interface PatternData {
+  stops: PatternStop[];
+  coordinates: number[][];
+}
+
+export interface SelectedRoute {
+  route_id?: string;
+  route_short_name?: string;
+  route_long_name?: string;
+  route_color?: string;
+  route_text_color?: string;
+  services: Array<{
+    organization_guid?: string;
+    organization_id?: string;
+    service_guid?: string;
+    service_id?: string;
+    agency_name?: string;
+  }>;
+}

--- a/utils/timeFormatters.ts
+++ b/utils/timeFormatters.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared time formatting utilities
+ */
+
+/**
+ * Format a timestamp as 12-hour time with AM/PM
+ * @param timestamp - Unix timestamp in milliseconds
+ * @returns Formatted time string (e.g., "3:45 PM")
+ */
+export function formatTime12Hour(timestamp: number): string {
+  const date = new Date(timestamp);
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  const ampm = hours >= 12 ? 'PM' : 'AM';
+  const displayHours = hours % 12 || 12;
+  const displayMinutes = minutes.toString().padStart(2, '0');
+  return `${displayHours}:${displayMinutes} ${ampm}`;
+}
+
+/**
+ * Format a timestamp as 24-hour time
+ * @param timestamp - Unix timestamp in milliseconds
+ * @returns Formatted time string (e.g., "15:45")
+ */
+export function formatTime24Hour(timestamp: number): string {
+  const date = new Date(timestamp);
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  return `${hours}:${minutes}`;
+}
+
+/**
+ * Format a duration in minutes to a human-readable string
+ * @param minutes - Duration in minutes
+ * @returns Formatted duration (e.g., "5 min", "1 hr 30 min")
+ */
+export function formatDuration(minutes: number): string {
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (mins === 0) {
+    return `${hours} hr${hours > 1 ? 's' : ''}`;
+  }
+  return `${hours} hr ${mins} min`;
+}
+
+/**
+ * Get relative time string (e.g., "in 5 minutes", "2 hours ago")
+ * @param timestamp - Unix timestamp in milliseconds
+ * @param now - Current time in milliseconds (optional)
+ * @returns Relative time string
+ */
+export function getRelativeTime(timestamp: number, now: number = Date.now()): string {
+  const diff = timestamp - now;
+  const absDiff = Math.abs(diff);
+  const minutes = Math.floor(absDiff / 60000);
+
+  if (minutes < 1) {
+    return diff > 0 ? 'arriving' : 'departed';
+  }
+
+  if (minutes < 60) {
+    const str = `${minutes} minute${minutes !== 1 ? 's' : ''}`;
+    return diff > 0 ? `in ${str}` : `${str} ago`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const str = `${hours} hour${hours !== 1 ? 's' : ''}`;
+  return diff > 0 ? `in ${str}` : `${str} ago`;
+}


### PR DESCRIPTION
This includes:

- Mapbox CSS file warning (now included through CDN)
- The stop arrivals slide was not using the route text color from the GTFS routes.txt file
- Fixes background image on Route Times slide
- Toggling the Map vs Timetable view now works correctly (it doesn't override your selection)
- Helper modules were added to reduce redundancy and reduce the route-specific coded I added to the published-page
- Get map to show consistently
- Add loading spinner for map
- In the evening and early morning, show upcoming route times, instead of leaving times blank
- Add better type support instead of `any` and fix Typescript errors
- Fix the hover color on the Map vs Timetable selector (was dark text on dark background)