### PR TITLE
fix: stop arrivals not populating correctly

### DIFF
--- a/app/pages/published-page.tsx
+++ b/app/pages/published-page.tsx
@@ -62,7 +62,7 @@ export default function PublishedPage({ shortcode }: { shortcode: string }) {
   const setRouteTimesIsLoading = useRouteTimesStore((state) => state.setIsLoading);
 
   const goToNextSlide = useCallback(() => {
-    setActiveIndex((prev) => (prev + 1) % slides.length);
+    setActiveIndex((currentIndex) => (currentIndex + 1) % slides.length);
   }, [slides.length]);
 
   const handleKeyDown = useCallback(
@@ -70,9 +70,9 @@ export default function PublishedPage({ shortcode }: { shortcode: string }) {
       if (!isTvMode) {return;} // Only handle keyboard navigation in TV mode
 
       if (event.key === 'ArrowRight') {
-        setActiveIndex((prev) => (prev + 1) % slides.length);
+        setActiveIndex((currentIndex) => (currentIndex + 1) % slides.length);
       } else if (event.key === 'ArrowLeft') {
-        setActiveIndex((prev) => (prev - 1 + slides.length) % slides.length);
+        setActiveIndex((currentIndex) => (currentIndex - 1 + slides.length) % slides.length);
       }
     },
     [slides.length, isTvMode]
@@ -99,15 +99,21 @@ export default function PublishedPage({ shortcode }: { shortcode: string }) {
   useEffect(() => {
     const loadSlides = async () => {
       if (shortcode) {
-        await SetupSlides(shortcode);
-        setIsLoading(false);
-        getTransitDestinationData();
-        getFixedRouteData();
-        getTransitRoutesData();
-        getRouteTimesData();
-        getWeatherData();
-        getCitibikeData();
-        getTrafficCorridorData();
+        try {
+          await SetupSlides(shortcode);
+          // Fetch data after successful setup
+          getTransitDestinationData();
+          getFixedRouteData();
+          getTransitRoutesData();
+          getRouteTimesData();
+          getWeatherData();
+          getCitibikeData();
+          getTrafficCorridorData();
+        } catch (error) {
+          console.error('[SETUP] Failed to load slides:', error);
+        } finally {
+          setIsLoading(false);
+        }
       }
     };
     loadSlides();
@@ -343,7 +349,8 @@ export default function PublishedPage({ shortcode }: { shortcode: string }) {
     for (const slide of transitRoutesSlides) {
       const currentState = useTransitRouteStore.getState().slides;
       const transitRouteData = currentState[slide.id]?.routes || [];
-      await getDestinationData(transitRouteData, slide.id, setRoutesData, setTransitRoutesDataError);
+      // Pass includeGeometry: true for transit-routes (needed for map visualization)
+      await getDestinationData(transitRouteData, slide.id, setRoutesData, setTransitRoutesDataError, [], { includeGeometry: true });
       const updatedState = useTransitRouteStore.getState().slides;
       const updatedData = updatedState[slide.id]?.routes || [];
       console.log(`[DATA UPDATE] Transit routes updated for slide ${slide.id}:`, updatedData);

--- a/app/pages/published-page.tsx
+++ b/app/pages/published-page.tsx
@@ -293,6 +293,7 @@ export default function PublishedPage({ shortcode }: { shortcode: string }) {
           routeFilteredArrivals = uniqueArrivals.filter(arr => {
             const selection = serviceSelections.find((s: any) => s.serviceId === arr._sourceService);
             if (!selection || !selection.enabledRouteIds) return true;
+            if (!arr.routeId) return true;
             return selection.enabledRouteIds.includes(arr.routeId);
           });
         }

--- a/components/slides/stop-arrivals.tsx
+++ b/components/slides/stop-arrivals.tsx
@@ -816,6 +816,7 @@ export default function StopArrivalsSlide({
         const selection = serviceSelections.find(s => s.serviceId === arr._sourceService);
         // If no selection found, no enabledRouteIds, or empty array, include the arrival
         if (!selection || !selection.enabledRouteIds || selection.enabledRouteIds.length === 0) return true;
+        if (!arr.routeId) return true;
         return selection.enabledRouteIds.includes(arr.routeId);
       });
 

--- a/services/data-gathering/fetchSkidsDestinationData.ts
+++ b/services/data-gathering/fetchSkidsDestinationData.ts
@@ -29,6 +29,13 @@ interface SkidsResult {
   legs?: SkidsLeg[];
 }
 
+interface SkidsStopInfo {
+  id: string;
+  name: string;
+  lat?: number;
+  lon?: number;
+}
+
 interface SkidsTransitLeg {
   type: 'transit';
   route: {
@@ -42,18 +49,21 @@ interface SkidsTransitLeg {
     agencyId?: string;    // GTFS agency_id (e.g., "MTA NYCT")
     agencyName?: string;  // Full agency name
   };
-  boardStop: { id: string; name: string };
-  alightStop: { id: string; name: string };
+  boardStop: SkidsStopInfo;
+  alightStop: SkidsStopInfo;
   boardTime: number;
   alightTime: number;
   headsign: string;
   stops: string[];
+  legGeometry?: {
+    points: string;  // Google-encoded polyline
+  };
 }
 
 interface SkidsTransferLeg {
   type: 'transfer';
-  fromStop: { id: string; name: string };
-  toStop: { id: string; name: string };
+  fromStop: SkidsStopInfo;
+  toStop: SkidsStopInfo;
   duration: number;
   distanceMeters?: number;
 }
@@ -65,8 +75,8 @@ export interface TransformedLeg {
   mode: string;
   duration: number;
   distanceMeters?: number;
-  from: { id: string; name: string };
-  to: { id: string; name: string };
+  from: { id: string; name: string; lat?: number; lon?: number };
+  to: { id: string; name: string; lat?: number; lon?: number };
   routeShortName?: string;
   routeColor?: string;
   routeTextColor?: string;
@@ -76,6 +86,9 @@ export interface TransformedLeg {
   headsign?: string;
   boardTime?: number;
   alightTime?: number;
+  legGeometry?: {
+    points: string;  // Google-encoded polyline
+  };
 }
 
 /** Transformed destination format expected by the UI */
@@ -115,8 +128,18 @@ function transformLeg(leg: SkidsLeg): TransformedLeg {
       mode: 'WALK',
       duration: leg.duration,
       distanceMeters: leg.distanceMeters,
-      from: leg.fromStop,
-      to: leg.toStop,
+      from: {
+        id: leg.fromStop.id,
+        name: leg.fromStop.name,
+        lat: leg.fromStop.lat,
+        lon: leg.fromStop.lon,
+      },
+      to: {
+        id: leg.toStop.id,
+        name: leg.toStop.name,
+        lat: leg.toStop.lat,
+        lon: leg.toStop.lon,
+      },
     };
   }
 
@@ -131,11 +154,22 @@ function transformLeg(leg: SkidsLeg): TransformedLeg {
     routeType: leg.route.type,
     agencyId: leg.route.agencyId,      // GTFS agency_id (e.g., "MTA NYCT")
     agencyName: leg.route.agencyName,  // Full agency name
-    from: leg.boardStop,
-    to: leg.alightStop,
+    from: {
+      id: leg.boardStop.id,
+      name: leg.boardStop.name,
+      lat: leg.boardStop.lat,
+      lon: leg.boardStop.lon,
+    },
+    to: {
+      id: leg.alightStop.id,
+      name: leg.alightStop.name,
+      lat: leg.alightStop.lat,
+      lon: leg.alightStop.lon,
+    },
     headsign: leg.headsign,
     boardTime: leg.boardTime,
     alightTime: leg.alightTime,
+    legGeometry: leg.legGeometry,
   };
 }
 
@@ -215,12 +249,18 @@ export function transformSkidsResponse(
   });
 }
 
+export interface FetchSkidsOptions {
+  /** Include shape geometry in response (for map visualization) */
+  includeGeometry?: boolean;
+}
+
 /**
  * Fetch transit routing data from Skids API for multiple destinations
  */
 export async function fetchSkidsTransitData(
   origin: { lat: number; lng: number },
-  destinations: { name: string; coordinates: { lat: number; lng: number } }[]
+  destinations: { name: string; coordinates: { lat: number; lng: number } }[],
+  options?: FetchSkidsOptions
 ): Promise<TransformedDestination[]> {
   if (!SKIDS_URL) {
     throw new Error('NEXT_PUBLIC_SKIDS_URL environment variable is not configured');
@@ -236,6 +276,7 @@ export async function fetchSkidsTransitData(
       })),
       options: {
         maxTransfers: 3,
+        includeGeometry: options?.includeGeometry ?? false,
       },
     }),
   });

--- a/services/data-gathering/fetchStopData.ts
+++ b/services/data-gathering/fetchStopData.ts
@@ -1,4 +1,4 @@
-import { formatTime, formatDuration } from '@/utils/formats';
+import { formatTime } from '@/utils/formats';
 
 // Maximum number of arrivals to display per slide
 export const MAX_ARRIVALS_PER_SLIDE = 6;
@@ -31,6 +31,36 @@ function findStatus(realtime: boolean, arrive: number, arriveScheduled: number) 
 const DEFAULT_ROUTE_COLOR = '0074D9';
 const DEFAULT_ROUTE_TEXT_COLOR = 'FFFFFF';
 
+const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+/**
+ * Format arrival as duration for same-day, or day + date for future dates.
+ * - Same day: "4 hr 24 min" or "45 min"
+ * - Future: "Tue 4/22", "Wed 4/23", etc.
+ */
+function formatSmartDuration(arrivalTimestamp: number, currentTime: number): string {
+  const arrivalDate = new Date(arrivalTimestamp);
+  const currentDate = new Date(currentTime);
+
+  // Get calendar dates (midnight) for comparison
+  const arrivalDay = new Date(arrivalDate.getFullYear(), arrivalDate.getMonth(), arrivalDate.getDate());
+  const currentDay = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate());
+
+  if (arrivalDay.getTime() === currentDay.getTime()) {
+    // Same day - show duration
+    const durationSeconds = Math.round((arrivalTimestamp - currentTime) / 1000);
+    const hours = Math.floor(durationSeconds / 3600);
+    const minutes = Math.floor((durationSeconds % 3600) / 60);
+    return `${hours > 0 ? `${hours} hr ` : ''}${minutes} min`;
+  } else {
+    // Future day - show day name + date (e.g., "Tue 4/22")
+    const dayName = DAY_NAMES[arrivalDate.getDay()];
+    const month = arrivalDate.getMonth() + 1;
+    const day = arrivalDate.getDate();
+    return `${dayName} ${month}/${day}`;
+  }
+}
+
 function formatBusData(data: any) {
   const currentTime = Date.now();
   const stationName = (data.name || '').toLowerCase().trim();
@@ -56,7 +86,7 @@ function formatBusData(data: any) {
       routeTextColor: train.textColor || DEFAULT_ROUTE_TEXT_COLOR,
       arrivalTime: formatTime(Math.round(train.arrive)),
       arrivalTimestamp: Math.round(train.arrive),  // Raw timestamp for sorting
-      arrival: formatDuration(Math.round((train.arriveScheduled - currentTime) / 1000)),
+      arrival: formatSmartDuration(train.arriveScheduled, currentTime),
       status: findStatus(train.realtime, train.arrive, train.arriveScheduled),
     })),
   };

--- a/services/data-gathering/fetchStopData.ts
+++ b/services/data-gathering/fetchStopData.ts
@@ -43,14 +43,14 @@ function formatBusData(data: any) {
     const headsign = (train.headsign || '').toLowerCase().trim();
     if (headsign && headsign === stationName) return false;
     return true;
-  }).slice(0, MAX_ARRIVALS_PER_SLIDE);
+  });
 
   return {
     station: data.name,
     trains: futureArrivals.map((train: any) => ({
       destination: train.headsign,
-      routeId: train.routeId || '',              // Actual GTFS route_id for filtering
-      routeShortName: train.shortName || train.routeId || '',  // Display name for UI
+      routeId: train.routeId || train.id?.split(':')[0] || '',
+      routeShortName: train.shortName || train.routeId || train.id?.split(':')[0] || '',
       routeType: train.routeType,
       routeColor: train.color || DEFAULT_ROUTE_COLOR,
       routeTextColor: train.textColor || DEFAULT_ROUTE_TEXT_COLOR,

--- a/services/data-gathering/getDestinationData.ts
+++ b/services/data-gathering/getDestinationData.ts
@@ -6,12 +6,18 @@ import { formatTime, formatDuration } from "@/utils/formats";
 // use Skids API by default, set to 'false' to use OTP
 const USE_SKIDS = process.env.NEXT_PUBLIC_USE_SKIDS !== 'false';
 
+export interface GetDestinationDataOptions {
+  /** Include shape geometry for map visualization (transit-routes slides) */
+  includeGeometry?: boolean;
+}
+
 export async function getDestinationData(
   destList: { name: string; coordinates: { lat: number; lng: number } }[],
   slideId: string,
   setDestinationData: (slideId: string, data: any[]) => void,
   setDataError: (slideId: string, error: boolean) => void,
-  currentDestinationData: any[] = []
+  currentDestinationData: any[] = [],
+  options?: GetDestinationDataOptions
 ) {
   if (!Array.isArray(currentDestinationData)) currentDestinationData = [];
   if (destList.length === 0) return;
@@ -39,7 +45,8 @@ export async function getDestinationData(
       // Response already has pre-formatted departure/arrival/travel strings
       const results = await fetchSkidsTransitData(
         { lat: coordinates.lat, lng: coordinates.lng },
-        destList
+        destList,
+        { includeGeometry: options?.includeGeometry }
       );
 
       const enrichedDestinations = results.map((data, index) => ({


### PR DESCRIPTION
- Tyler's fix for trains
- Jon updated the RAPTOR-based transit routing to include geometry like OTP does, so `main` can use that service now
- For stops that show times for other days, show the actual day and date instead of "45 hours" etc.